### PR TITLE
test: align artifact fixtures with validators

### DIFF
--- a/tests/fixtures/iteration-log.example.md
+++ b/tests/fixtures/iteration-log.example.md
@@ -5,6 +5,7 @@
 **Completed:** 2026-04-05
 **Stories delivered:** STORY-0001
 **Tasks executed:** 1
+**Scenarios:** JOURNEY-0001
 **Summary:** Implemented the greet command end-to-end. The CLI accepts a name argument and prints a personalized greeting.
 **Learnings:** The walking skeleton revealed that argument parsing needs to distinguish missing-argument from empty-string cases. No roadmap revision needed.
 **Roadmap revisions:** none

--- a/tests/fixtures/roadmap.example.md
+++ b/tests/fixtures/roadmap.example.md
@@ -4,6 +4,7 @@
 
 **Intent:** The thinnest end-to-end slice that exercises the full product shape.
 **Design rationale:** Implement the single greet command end-to-end; this is the entire v0 and proves the CLI entry point works.
+**Journey scenario:** JOURNEY-0001
 **Stories committed:**
 - STORY-0001 (EPIC-001)
 **Status:** pending


### PR DESCRIPTION
## Summary\n- add the required Journey scenario field to the valid roadmap fixture\n- add the required Scenarios field to the valid iteration-log fixture\n\n## Verification\n- ./scripts/run_validation_suite.sh\n\n## Context\nThe validators require these fields, so the current valid fixtures make the validation suite fail before any plugin adoption/evaluation work can run cleanly.